### PR TITLE
Allow importing regular SVG icons

### DIFF
--- a/SidebarFavorites.xcodeproj/project.pbxproj
+++ b/SidebarFavorites.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C0D3A11E0000000000000002 /* CustomSVGConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3A11E0000000000000001 /* CustomSVGConverter.swift */; };
 		052520887DBA2F305505E718 /* SymbolValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FEE397CF7C0505AB617A9E /* SymbolValidator.swift */; };
 		0552EC52E6F42FD0F91E5974 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E62EDE72F4C95ED46D7AD2E /* Config.swift */; };
 		07BA8A489C7EA8A5B7B03893 /* AppIcon.icns in Resources */ = {isa = PBXBuildFile; fileRef = 0BD2B23709F81767F72E8B18 /* AppIcon.icns */; };
@@ -80,6 +81,7 @@
 		3A2A9F10C3173CBCF0F69A60 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4DF501B60A6EFDEE8A296225 /* LifecycleManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleManager.swift; sourceTree = "<group>"; };
 		52FEE397CF7C0505AB617A9E /* SymbolValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolValidator.swift; sourceTree = "<group>"; };
+		C0D3A11E0000000000000001 /* CustomSVGConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomSVGConverter.swift; sourceTree = "<group>"; };
 		56994A0E52942D4D13A9956B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		57F4170519CA0B2F3C4CC1D5 /* SVGThumbnailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SVGThumbnailView.swift; sourceTree = "<group>"; };
 		62A8E5D947DF6094E78DAC1B /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -187,6 +189,7 @@
 		EC6B0ACA83F7A825C9E3CA98 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				C0D3A11E0000000000000001 /* CustomSVGConverter.swift */,
 				EED494CB3B8D7A4460544CF9 /* ConfigManager.swift */,
 				692364F82536C38D6D9534FC /* IconAppGenerator.swift */,
 				4DF501B60A6EFDEE8A296225 /* LifecycleManager.swift */,
@@ -372,6 +375,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3449045C82D58B47741DDADC /* AddEditFavoriteSheet.swift in Sources */,
+				C0D3A11E0000000000000002 /* CustomSVGConverter.swift in Sources */,
 				0552EC52E6F42FD0F91E5974 /* Config.swift in Sources */,
 				F32E055B42B58F53E01013A1 /* ConfigManager.swift in Sources */,
 				2876AF87BAC9189EE99832FC /* ContentView.swift in Sources */,

--- a/SidebarFavoritesManager/Services/CustomSVGConverter.swift
+++ b/SidebarFavoritesManager/Services/CustomSVGConverter.swift
@@ -1,0 +1,349 @@
+import AppKit
+import Foundation
+
+/// Converts a regular vector SVG into the SF Symbols template used by Finder favorites.
+enum CustomSVGConverter {
+    enum ConversionError: LocalizedError {
+        case invalidSVG
+        case unsupportedContent(String)
+        case noArtwork
+        case missingTemplate
+        case couldNotMeasure
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidSVG:
+                return "The selected file is not a valid SVG."
+            case .unsupportedContent(let content):
+                return "This SVG contains unsupported \(content). Convert it to vector paths first."
+            case .noArtwork:
+                return "No visible vector paths or shapes were found in this SVG."
+            case .missingTemplate:
+                return "The bundled custom symbol template could not be loaded."
+            case .couldNotMeasure:
+                return "The SVG artwork could not be measured."
+            }
+        }
+    }
+
+    private struct Matrix {
+        var a: CGFloat = 1
+        var b: CGFloat = 0
+        var c: CGFloat = 0
+        var d: CGFloat = 1
+        var tx: CGFloat = 0
+        var ty: CGFloat = 0
+
+        func multiplied(by other: Matrix) -> Matrix {
+            Matrix(
+                a: a * other.a + c * other.b,
+                b: b * other.a + d * other.b,
+                c: a * other.c + c * other.d,
+                d: b * other.c + d * other.d,
+                tx: a * other.tx + c * other.ty + tx,
+                ty: b * other.tx + d * other.ty + ty
+            )
+        }
+
+        static func translation(_ x: CGFloat, _ y: CGFloat) -> Matrix {
+            Matrix(tx: x, ty: y)
+        }
+
+        static func scale(_ x: CGFloat, _ y: CGFloat) -> Matrix {
+            Matrix(a: x, d: y)
+        }
+
+        static func rotation(_ radians: CGFloat) -> Matrix {
+            Matrix(a: cos(radians), b: sin(radians), c: -sin(radians), d: cos(radians))
+        }
+
+        var svgValue: String {
+            [a, b, c, d, tx, ty]
+                .map { String(format: "%.6f", Double($0)) }
+                .joined(separator: " ")
+        }
+    }
+
+    private struct ArtworkElement {
+        let element: XMLElement
+        let transform: Matrix
+    }
+
+    private static let graphicNames = Set(["path", "rect", "circle", "ellipse", "polygon", "polyline", "line"])
+    private static let skippedContainers = Set(["defs", "clippath", "mask", "metadata", "title", "desc", "style"])
+    private static let geometryAttributes = Set(["d", "x", "y", "x1", "y1", "x2", "y2", "cx", "cy", "r", "rx", "ry", "width", "height", "points"])
+    private static let styleNames = [
+        "fill", "fill-opacity", "fill-rule", "stroke", "stroke-opacity", "stroke-width",
+        "stroke-linecap", "stroke-linejoin", "display", "visibility", "opacity"
+    ]
+    private static let variants: [(id: String, centerX: CGFloat)] = [
+        ("Black-S", 2933.4),
+        ("Regular-S", 1449.845),
+        ("Ultralight-S", 559.711)
+    ]
+
+    static func convert(sourceURL: URL, templateURL: URL, symbolName: String) throws -> String {
+        let sourceData = try Data(contentsOf: sourceURL)
+        let sourceText = String(data: sourceData, encoding: .utf8) ?? ""
+        try validateSafety(sourceText)
+
+        let sourceDocument: XMLDocument
+        do {
+            sourceDocument = try XMLDocument(data: sourceData, options: [.nodeLoadExternalEntitiesNever])
+        } catch {
+            throw ConversionError.invalidSVG
+        }
+        guard let root = sourceDocument.rootElement(), root.localName?.lowercased() == "svg" else {
+            throw ConversionError.invalidSVG
+        }
+
+        let sourceBox = try viewBox(of: root)
+        let artworkBox = try visibleArtworkBounds(data: sourceData, viewBox: sourceBox)
+        var artwork: [ArtworkElement] = []
+        collectArtwork(from: root, parentTransform: Matrix(), inheritedStyle: [:], output: &artwork)
+        guard !artwork.isEmpty else { throw ConversionError.noArtwork }
+
+        let templateData: Data
+        do {
+            templateData = try Data(contentsOf: templateURL)
+        } catch {
+            throw ConversionError.missingTemplate
+        }
+        let templateDocument: XMLDocument
+        do {
+            templateDocument = try XMLDocument(data: templateData, options: [.nodeLoadExternalEntitiesNever])
+        } catch {
+            throw ConversionError.missingTemplate
+        }
+        guard let symbols = try templateDocument.nodes(forXPath: "//*[@id='Symbols']").first as? XMLElement else {
+            throw ConversionError.missingTemplate
+        }
+
+        while symbols.childCount > 0 { symbols.removeChild(at: 0) }
+        let scale = min(108 / artworkBox.width, 70.459 / artworkBox.height)
+        let centerY: CGFloat = 660.7705
+
+        for variant in variants {
+            let group = XMLElement(name: "g")
+            group.addAttribute(XMLNode.attribute(withName: "id", stringValue: variant.id) as! XMLNode)
+            let placement = Matrix.translation(
+                variant.centerX - scale * artworkBox.midX,
+                centerY - scale * artworkBox.midY
+            ).multiplied(by: .scale(scale, scale))
+
+            for item in artwork {
+                guard let element = item.element.copy() as? XMLElement else { continue }
+                let transform = placement.multiplied(by: item.transform)
+                element.addAttribute(XMLNode.attribute(withName: "transform", stringValue: "matrix(\(transform.svgValue))") as! XMLNode)
+                group.addChild(element)
+            }
+            symbols.addChild(group)
+            // SVGThumbnailView includes one character after </g>; keep it harmless whitespace.
+            symbols.addChild(XMLNode.text(withStringValue: "\n  ") as! XMLNode)
+        }
+
+        if let descriptiveName = try templateDocument.nodes(forXPath: "//*[@id='descriptive-name']").first as? XMLElement {
+            while descriptiveName.childCount > 0 { descriptiveName.removeChild(at: 0) }
+            let tspan = XMLElement(name: "tspan")
+            tspan.stringValue = sanitizedSymbolName(symbolName)
+            descriptiveName.addChild(tspan)
+        }
+
+        return templateDocument.xmlString(options: [.nodePrettyPrint])
+    }
+
+    private static func validateSafety(_ source: String) throws {
+        let lowercased = source.lowercased()
+        let unsupported: [(String, String)] = [
+            ("<script", "scripts"),
+            ("<foreignobject", "embedded HTML"),
+            ("<image", "raster images"),
+            ("<text", "live text"),
+            ("<use", "reusable SVG instances"),
+            ("<!doctype", "external document declarations")
+        ]
+        if let match = unsupported.first(where: { lowercased.contains($0.0) }) {
+            throw ConversionError.unsupportedContent(match.1)
+        }
+        if lowercased.range(of: #"(?:href|xlink:href)\s*=\s*["'](?:https?:|data:|//)"#, options: .regularExpression) != nil {
+            throw ConversionError.unsupportedContent("external resources")
+        }
+    }
+
+    private static func viewBox(of root: XMLElement) throws -> CGRect {
+        if let value = root.attribute(forName: "viewBox")?.stringValue {
+            let numbers = parseNumbers(value)
+            if numbers.count == 4, numbers[2] > 0, numbers[3] > 0 {
+                return CGRect(x: numbers[0], y: numbers[1], width: numbers[2], height: numbers[3])
+            }
+        }
+        let width = root.attribute(forName: "width")?.stringValue.flatMap { parseNumbers($0).first }
+        let height = root.attribute(forName: "height")?.stringValue.flatMap { parseNumbers($0).first }
+        guard let width, let height, width > 0, height > 0 else { throw ConversionError.invalidSVG }
+        return CGRect(x: 0, y: 0, width: width, height: height)
+    }
+
+    private static func visibleArtworkBounds(data: Data, viewBox: CGRect) throws -> CGRect {
+        guard let image = NSImage(data: data) else { throw ConversionError.couldNotMeasure }
+        let rasterScale = min(1024 / max(viewBox.width, viewBox.height), 8)
+        let width = max(1, Int(ceil(viewBox.width * rasterScale)))
+        let height = max(1, Int(ceil(viewBox.height * rasterScale)))
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: width,
+            pixelsHigh: height,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bitmapFormat: [],
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ), let context = NSGraphicsContext(bitmapImageRep: bitmap) else {
+            throw ConversionError.couldNotMeasure
+        }
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = context
+        context.cgContext.clear(CGRect(x: 0, y: 0, width: width, height: height))
+        image.draw(in: CGRect(x: 0, y: 0, width: width, height: height), from: .zero, operation: .sourceOver, fraction: 1)
+        context.flushGraphics()
+        NSGraphicsContext.restoreGraphicsState()
+
+        var minX = width
+        var minY = height
+        var maxX = -1
+        var maxY = -1
+        for y in 0..<height {
+            for x in 0..<width where (bitmap.colorAt(x: x, y: y)?.alphaComponent ?? 0) > 0.01 {
+                minX = min(minX, x)
+                minY = min(minY, y)
+                maxX = max(maxX, x)
+                maxY = max(maxY, y)
+            }
+        }
+        guard maxX >= minX, maxY >= minY else { throw ConversionError.noArtwork }
+
+        let x1 = viewBox.minX + CGFloat(minX) / CGFloat(width) * viewBox.width
+        let x2 = viewBox.minX + CGFloat(maxX + 1) / CGFloat(width) * viewBox.width
+        let y1 = viewBox.minY + CGFloat(height - maxY - 1) / CGFloat(height) * viewBox.height
+        let y2 = viewBox.minY + CGFloat(height - minY) / CGFloat(height) * viewBox.height
+        return CGRect(x: x1, y: y1, width: x2 - x1, height: y2 - y1)
+    }
+
+    private static func collectArtwork(
+        from element: XMLElement,
+        parentTransform: Matrix,
+        inheritedStyle: [String: String],
+        output: inout [ArtworkElement]
+    ) {
+        let name = (element.localName ?? element.name ?? "").lowercased()
+        if skippedContainers.contains(name) { return }
+
+        var style = inheritedStyle
+        for key in styleNames {
+            if let value = element.attribute(forName: key)?.stringValue { style[key] = value }
+        }
+        if let inlineStyle = element.attribute(forName: "style")?.stringValue {
+            for declaration in inlineStyle.split(separator: ";") {
+                let pair = declaration.split(separator: ":", maxSplits: 1).map(String.init)
+                if pair.count == 2 { style[pair[0].trimmingCharacters(in: .whitespaces)] = pair[1].trimmingCharacters(in: .whitespaces) }
+            }
+        }
+        if style["display"] == "none" || style["visibility"] == "hidden"
+            || (style["opacity"].map { number($0) == 0 } ?? false) { return }
+
+        let localTransform = parseTransform(element.attribute(forName: "transform")?.stringValue ?? "")
+        let transform = parentTransform.multiplied(by: localTransform)
+        if graphicNames.contains(name), let clean = cleanElement(element, style: style) {
+            output.append(ArtworkElement(element: clean, transform: transform))
+        }
+        for child in element.children ?? [] {
+            if let child = child as? XMLElement {
+                collectArtwork(from: child, parentTransform: transform, inheritedStyle: style, output: &output)
+            }
+        }
+    }
+
+    private static func cleanElement(_ source: XMLElement, style: [String: String]) -> XMLElement? {
+        let name = source.localName ?? source.name ?? "path"
+        let element = XMLElement(name: name)
+        for attribute in source.attributes ?? [] where geometryAttributes.contains(attribute.name ?? "") {
+            element.addAttribute(attribute.copy() as! XMLNode)
+        }
+
+        let fillVisible = style["fill"]?.lowercased() != "none"
+            && style["fill"]?.lowercased() != "transparent"
+            && number(style["fill-opacity"], fallback: 1) > 0
+        let strokeValue = style["stroke"]?.lowercased() ?? "none"
+        let strokeVisible = strokeValue != "none" && strokeValue != "transparent"
+            && number(style["stroke-opacity"], fallback: 1) > 0
+        guard fillVisible || strokeVisible else { return nil }
+
+        element.addAttribute(XMLNode.attribute(withName: "fill", stringValue: fillVisible ? "#000" : "none") as! XMLNode)
+        element.addAttribute(XMLNode.attribute(withName: "stroke", stringValue: strokeVisible ? "#000" : "none") as! XMLNode)
+        for key in ["fill-rule", "stroke-width", "stroke-linecap", "stroke-linejoin"] {
+            if let value = style[key] {
+                element.addAttribute(XMLNode.attribute(withName: key, stringValue: value) as! XMLNode)
+            }
+        }
+        return element
+    }
+
+    private static func parseTransform(_ value: String) -> Matrix {
+        guard let regex = try? NSRegularExpression(pattern: #"([A-Za-z]+)\s*\(([^)]*)\)"#) else { return Matrix() }
+        let matches = regex.matches(in: value, range: NSRange(value.startIndex..., in: value))
+        return matches.reduce(Matrix()) { result, match in
+            guard let nameRange = Range(match.range(at: 1), in: value),
+                  let valuesRange = Range(match.range(at: 2), in: value) else { return result }
+            let name = value[nameRange].lowercased()
+            let values = parseNumbers(String(value[valuesRange]))
+            let transform: Matrix
+            switch name {
+            case "matrix" where values.count == 6:
+                transform = Matrix(a: values[0], b: values[1], c: values[2], d: values[3], tx: values[4], ty: values[5])
+            case "translate" where !values.isEmpty:
+                transform = .translation(values[0], values.count > 1 ? values[1] : 0)
+            case "scale" where !values.isEmpty:
+                transform = .scale(values[0], values.count > 1 ? values[1] : values[0])
+            case "rotate" where !values.isEmpty:
+                let rotation = Matrix.rotation(values[0] * .pi / 180)
+                if values.count >= 3 {
+                    transform = Matrix.translation(values[1], values[2])
+                        .multiplied(by: rotation)
+                        .multiplied(by: .translation(-values[1], -values[2]))
+                } else {
+                    transform = rotation
+                }
+            case "skewx" where !values.isEmpty:
+                transform = Matrix(c: tan(values[0] * .pi / 180))
+            case "skewy" where !values.isEmpty:
+                transform = Matrix(b: tan(values[0] * .pi / 180))
+            default:
+                transform = Matrix()
+            }
+            return result.multiplied(by: transform)
+        }
+    }
+
+    private static func parseNumbers(_ value: String) -> [CGFloat] {
+        guard let regex = try? NSRegularExpression(pattern: #"[-+]?(?:\d*\.\d+|\d+\.?)(?:[eE][-+]?\d+)?"#) else { return [] }
+        return regex.matches(in: value, range: NSRange(value.startIndex..., in: value)).compactMap { match in
+            guard let range = Range(match.range, in: value), let number = Double(value[range]) else { return nil }
+            return CGFloat(number)
+        }
+    }
+
+    private static func number(_ value: String?, fallback: CGFloat = 0) -> CGFloat {
+        guard let value, let number = Double(value) else { return fallback }
+        return CGFloat(number)
+    }
+
+    private static func sanitizedSymbolName(_ name: String) -> String {
+        let cleaned = name.lowercased()
+            .replacingOccurrences(of: #"[^a-z0-9._-]+"#, with: ".", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+        return cleaned.isEmpty ? "custom.symbol" : cleaned
+    }
+}

--- a/SidebarFavoritesManager/Services/SymbolValidator.swift
+++ b/SidebarFavoritesManager/Services/SymbolValidator.swift
@@ -25,6 +25,7 @@ struct SymbolValidator {
         case missingRegularVariant
         case missingUltralightVariant
         case missingBlackVariant
+        case conversionFailed(String)
 
         var errorDescription: String? {
             switch self {
@@ -44,6 +45,8 @@ struct SymbolValidator {
                 return "Missing Ultralight-S weight variant"
             case .missingBlackVariant:
                 return "Missing Black-S weight variant"
+            case .conversionFailed(let message):
+                return message
             }
         }
     }
@@ -114,23 +117,51 @@ struct SymbolValidator {
         let relativePath = "\(name).svg"
         let destinationURL = configManager.iconsDirectoryURL.appendingPathComponent(relativePath)
 
-        // Validate first
-        let result = validate(at: sourceURL)
-        guard result.isValid else {
-            throw ImportError.validationFailed(result.errors)
+        guard let source = try? String(contentsOf: sourceURL, encoding: .utf8) else {
+            throw ImportError.validationFailed([.fileNotReadable])
         }
-
-        // Copy to Icons directory
-        if FileManager.default.fileExists(atPath: destinationURL.path) {
-            try FileManager.default.removeItem(at: destinationURL)
+        let result = validate(content: source)
+        if result.isValid {
+            if FileManager.default.fileExists(atPath: destinationURL.path) {
+                try FileManager.default.removeItem(at: destinationURL)
+            }
+            try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+        } else {
+            guard !source.contains("id=\"Symbols\"") else {
+                throw ImportError.validationFailed(result.errors)
+            }
+            guard let templateURL = Bundle.main.url(forResource: "custom-icon-template", withExtension: "svg") else {
+                throw ImportError.validationFailed([.conversionFailed("The bundled custom symbol template could not be loaded.")])
+            }
+            do {
+                let converted = try CustomSVGConverter.convert(
+                    sourceURL: sourceURL,
+                    templateURL: templateURL,
+                    symbolName: name
+                )
+                let convertedResult = validate(content: converted)
+                guard convertedResult.isValid else {
+                    throw ImportError.validationFailed(convertedResult.errors)
+                }
+                try converted.write(to: destinationURL, atomically: true, encoding: .utf8)
+            } catch let error as ImportError {
+                throw error
+            } catch {
+                throw ImportError.validationFailed([.conversionFailed(error.localizedDescription)])
+            }
         }
-        try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
 
         return relativePath
     }
 
     enum ImportError: LocalizedError {
         case validationFailed([ValidationError])
+
+        var errors: [ValidationError] {
+            switch self {
+            case .validationFailed(let errors): return errors
+            }
+        }
 
         var errorDescription: String? {
             switch self {

--- a/SidebarFavoritesManager/Views/AddEditFavoriteSheet.swift
+++ b/SidebarFavoritesManager/Views/AddEditFavoriteSheet.swift
@@ -18,6 +18,7 @@ struct AddEditFavoriteSheet: View {
     @State private var showingTemplateGuidelines = false
     @State private var validationErrors: [SymbolValidator.ValidationError] = []
     @State private var showingValidationError = false
+    @State private var previewRevision = UUID()
 
     private var isEditing: Bool { existingFavorite != nil }
 
@@ -183,7 +184,7 @@ struct AddEditFavoriteSheet: View {
             } else {
                 HStack(spacing: 12) {
                     Button(action: { showingSVGPicker = true }) {
-                        Label("Import Custom SVG...", systemImage: "square.and.arrow.down")
+                        Label("Import SVG...", systemImage: "square.and.arrow.down")
                     }
 
                     Button(action: { saveBlankTemplate() }) {
@@ -192,7 +193,7 @@ struct AddEditFavoriteSheet: View {
                 }
             }
 
-            Text("Import an existing SVG or save a blank template to create your own")
+            Text("Choose any vector SVG. Regular logos are converted automatically.")
                 .font(.caption)
                 .foregroundColor(.secondary)
         }
@@ -222,6 +223,7 @@ struct AddEditFavoriteSheet: View {
         if iconType == .custom, let svgPath = customSVGPath {
             let url = ConfigManager.shared.customIconURL(relativePath: svgPath)
             SVGThumbnailView(url: url, size: 16)
+                .id(previewRevision)
         } else {
             Image(systemName: iconValue)
         }
@@ -278,19 +280,21 @@ struct AddEditFavoriteSheet: View {
     }
 
     private func importCustomSVG(from url: URL) {
-        let result = SymbolValidator.validate(at: url)
-        if result.isValid {
-            do {
-                let symbolName = url.deletingPathExtension().lastPathComponent
-                let relativePath = try SymbolValidator.importSymbol(from: url, named: symbolName)
-                customSVGPath = relativePath
-                iconValue = symbolName
-            } catch {
-                validationErrors = []
-                showingValidationError = true
+        do {
+            let symbolName = url.deletingPathExtension().lastPathComponent
+            let relativePath = try SymbolValidator.importSymbol(from: url, named: symbolName)
+            customSVGPath = relativePath
+            iconValue = symbolName
+            let importedURL = ConfigManager.shared.customIconURL(relativePath: relativePath)
+            Task {
+                await SVGThumbnailCache.shared.invalidate(for: importedURL)
+                await MainActor.run { previewRevision = UUID() }
             }
-        } else {
-            validationErrors = result.errors
+        } catch let error as SymbolValidator.ImportError {
+            validationErrors = error.errors
+            showingValidationError = true
+        } catch {
+            validationErrors = [.conversionFailed(error.localizedDescription)]
             showingValidationError = true
         }
     }

--- a/scripts/test-svg-converter.swift
+++ b/scripts/test-svg-converter.swift
@@ -1,0 +1,54 @@
+import AppKit
+import Foundation
+
+@main
+struct CustomSVGConverterCheck {
+    static func main() throws {
+        guard (3...4).contains(CommandLine.arguments.count) else {
+            print("usage: test-svg-converter <template.svg> <output.svg> [source.svg]")
+            exit(2)
+        }
+
+        let source = """
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+          <g transform="translate(2 1)" fill="#f00">
+            <path d="M3 3h16v16H3z"/>
+          </g>
+        </svg>
+        """
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("sidebar-favorites-plain.svg")
+        let sourceURL: URL
+        if CommandLine.arguments.count == 4 {
+            sourceURL = URL(fileURLWithPath: CommandLine.arguments[3])
+        } else {
+            try source.write(to: tempURL, atomically: true, encoding: .utf8)
+            sourceURL = tempURL
+        }
+        defer { if sourceURL == tempURL { try? FileManager.default.removeItem(at: tempURL) } }
+
+        let output = try CustomSVGConverter.convert(
+            sourceURL: sourceURL,
+            templateURL: URL(fileURLWithPath: CommandLine.arguments[1]),
+            symbolName: "plain.logo"
+        )
+        precondition(output.contains("<g id=\"Regular-S\">"))
+        precondition(output.contains("<g id=\"Ultralight-S\">"))
+        precondition(output.contains("<g id=\"Black-S\">"))
+        precondition(!output.lowercased().contains("<script"))
+
+        let start = output.range(of: "<g id=\"Regular-S\">")!
+        let end = output.range(of: "</g>", range: start.upperBound..<output.endIndex)!
+        let extractedGroup = String(output[start.lowerBound...end.upperBound]) // Matches the app's current preview extraction.
+        let preview = """
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="1389.79 620.541 120.11 80.459">
+          \(extractedGroup)
+        </svg>
+        """
+        precondition(NSImage(data: preview.data(using: .utf8)!) != nil)
+
+        let outputURL = URL(fileURLWithPath: CommandLine.arguments[2])
+        try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try output.write(to: outputURL, atomically: true, encoding: .utf8)
+        print("PASS: \(outputURL.path)")
+    }
+}


### PR DESCRIPTION
This change lets users select a regular SVG logo for a custom icon.

The app automatically converts it into the format required by Finder and the app preview, fits it to the largest safe size, and makes it black.

Users no longer need to download or manually edit the SVG template.

Existing compatible custom SVG files will continue to work.